### PR TITLE
Mobile viewing optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ deps:
 serve:
 	cd webapp ; \
 	node_modules/.bin/watchify -t reactify frontend/* -o static/frontend.js & \
-	dev_appserver.py .
+	dev_appserver.py --host=0.0.0.0 .

--- a/webapp/frontend/review.jsx
+++ b/webapp/frontend/review.jsx
@@ -28,15 +28,12 @@ var Review = React.createClass({
 
         return <div className="review_workspace">
             <ReviewedStack collection={hardStack}
-                           position={{x: 800, y: 90}}
                            name='Hard' />
             <ReviewedStack collection={easyStack}
-                           position={{x: 800, y: 310}}
                            name='Easy' />
 
             <ReviewingStack collection={this.state.reviewingStack}
-                            rate={rate}
-                            position={{x: 50, y: 90}} />
+                            rate={rate} />
         </div>;
     },
     getInitialState: function() {
@@ -67,10 +64,6 @@ var ReviewingStack = React.createClass({
     render: function() {
         var topCardModel = _(this.props.collection.models).first();
         var sideLayers = Math.max(1, this.props.collection.models.length);
-        var allstyle = {
-            left: this.props.position.x,
-            top: this.props.position.y
-        };
         var stackstyle = {
             'box-shadow': stackSides('#2C3E50', '#BDC3C7', 2, sideLayers)
         };
@@ -93,7 +86,7 @@ var ReviewingStack = React.createClass({
                 {topCard}
             </div>;
         }
-        return <div className='reviewingstackall' style={allstyle}>
+        return <div className='reviewingstackall'>
             <ReviewingStackMeta
                     count={this.props.collection.models.length}
                     name='Remaining' />
@@ -122,11 +115,6 @@ var ReviewedStack = React.createClass({
     mixins: [BackboneMixin],
     render: function() {
         var sideLayers = this.props.collection.models.length;
-        var allstyle = {
-            left: this.props.position.x,
-            top: this.props.position.y
-        };
-
         var stackstyle = {
             'box-shadow': stackSides('#2C3E50', '#BDC3C7', 2, sideLayers)
         };
@@ -139,7 +127,7 @@ var ReviewedStack = React.createClass({
         } else {
             topCard = null;
         }
-        return <div className='reviewedstackall' style={allstyle}>
+        return <div className={'reviewedstackall reviewedstackall-' + this.props.name.toLowerCase()}>
             <ReviewedStackMeta count={this.props.collection.models.length}
                                name={this.props.name} />
             <div className='reviewedstack' style={stackstyle}>

--- a/webapp/static/frontend.css
+++ b/webapp/static/frontend.css
@@ -155,7 +155,7 @@ body {
     /*padding: 15px 9px 14px !important;*/
 }
 
-.takecard, 
+.takecard,
 .deletecard {
     padding-left: 10px;
     float: right;
@@ -200,6 +200,9 @@ body {
     width: 700px;
     height: 400px;
     position: absolute;
+
+    left: 90px;
+    top: 50px;
 }
 
 .reviewingstackmeta {
@@ -223,6 +226,16 @@ body {
     width: 400px;
     height: 200px;
     position: absolute;
+}
+
+.reviewedstackall-hard {
+    left: 800px;
+    top: 90px;
+}
+
+.reviewedstackall-easy {
+    left: 800px;
+    top: 310px;
 }
 
 .reviewedstackmeta {
@@ -386,6 +399,68 @@ body {
     padding: 5px;
 }
 
+@media only screen and (min-device-width: 320px) and (max-device-width: 480px) {
+    /* iPhone, Android rules here */
+    .reviewingstack {
+        width: 300px;
+        height: 300px;
+    }
+
+    .reviewingstackmeta {
+
+        float: none;
+        height: 70px;
+    }
+
+    .reviewingstackall {
+        width: 700px;
+        height: 400px;
+        position: absolute;
+
+        left: 10px;
+        top: 50px;
+    }
+
+    .reviewedstackall {
+        width: 100px;
+        height: 100px;
+        position: relative;
+        display: inline-block;
+    }
+
+    .reviewedstack {
+        /* Just hide these on mobile */
+        display: none;
+    }
+
+    .reviewedstackall-hard {
+        left: 10px;
+        top: 380px;
+    }
+
+    .reviewedstackall-easy {
+        left: 10px;
+        top: 380px;
+        margin-left: 150px;
+    }
+
+    .content {
+        margin-top: 10%;
+        font-size: large;
+    }
+
+    .choices {
+        padding-left: 200px
+    }
+
+    .choices_hard {
+        margin-left: 0px;
+    }
+
+    .emptyreviewingstack {
+        padding-top: 50px;
+    }
+}
 
 
 


### PR DESCRIPTION
This includes a change to access the page from a mobile device as well as some new CSS rules to make the card reviewing page look good on a portrait-mode phone. I hid the actual queue of completed cards since I thought that information was not critical.

It looks like this.

![screen shot 2014-07-18 at 10 04 51 pm](https://cloud.githubusercontent.com/assets/2415796/3633885/41d84504-0f02-11e4-84ed-ae64f670a2ac.png)

Next up:
- Debug style on an actual device, this is just the emulator and on my actual device it was a little difficult to click the "easy" and "hard" buttons, so I think I need to make them larger.
- Re-styling the nav bar
- Figuring out why the "make more" and "continue practicing" links do nothing
